### PR TITLE
Move to private object storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# secrets
+clouds.yaml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/app/main.py
+++ b/app/main.py
@@ -8,7 +8,7 @@ needed by IM
 import asyncio
 from contextlib import asynccontextmanager
 
-from app.glue import S3SiteStore, VOStore
+from app.glue import FileSiteStore, VOStore
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings
@@ -46,7 +46,7 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
-site_store = S3SiteStore(settings)
+site_store = FileSiteStore(settings)
 vo_store = VOStore(settings)
 
 

--- a/deploy/fetch-info.sh
+++ b/deploy/fetch-info.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# this will make the update not to happen if any of the intermediate
+# steps fail
+set -e
+
+CLOUD_INFO_DIR="$1"
+CLOUD_INFO_CLOUD="cloud-info"
+CLOUD_INFO_CONTAINER="cloud-info"
+
+DIR="$(mktemp -d)"
+for f in $(openstack --os-cloud "$CLOUD_INFO_CLOUD" \
+	object list "$CLOUD_INFO_CONTAINER" -f json | jq -r -n 'inputs[] | values[]'); do
+  echo "Downloading: $f"
+  openstack --os-cloud "$CLOUD_INFO_CLOUD" object save \
+	  "$CLOUD_INFO_CONTAINER" --file "$DIR/$(dirname $f).json" "$f"
+done
+
+rsync -a --delete-after "$DIR/" "$CLOUD_INFO_DIR"
+

--- a/deploy/playbook.yaml
+++ b/deploy/playbook.yaml
@@ -61,13 +61,28 @@
         version: "{{ git_ref }}"
         dest: /cloud-info-api
 
+    - name: Create a directory for storing cloud-info jsons
+      ansible.builtin.file:
+        path: /var/lib/cloud-info
+        state: directory
+        mode: '0755'
+
     - name: env file
       ansible.builtin.copy:
         content: |
           API_HOSTNAME="is.ops.fedcloud.eu"
           TAG="sha-{{ git_ref[0:7] }}"
           OPS_PORTAL_TOKEN="{{ ops_portal_token }}"
+          CLOUD_INFO_DIR="/var/lib/cloud-info"
         dest: /cloud-info-api/.env
+
+    - name: Fetch cloud info regularly
+      ansible.builtin.cron:
+        name: cloud-info-fetcher
+        minute: "*/10"
+        job: >
+          /cloud-info-api/deploy/fetch-info.sh /var/lib/cloud-info
+        cron_file: "cloud-info-fetcher"
 
     - name: service file
       ansible.builtin.copy:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,6 +37,9 @@ services:
       - "traefik.http.routers.api.tls.certresolver=myresolver"
     environment:
       - OPS_PORTAL_TOKEN=${OPS_PORTAL_TOKEN}
+      - CLOUD_INFO_DIR=/var/lib/cloud-info
+    volumes:
+      - "${CLOUD_INFO_DIR}:/var/lib/cloud-info"
     deploy:
       restart_policy:
         condition: any


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

cloud info is no longer available without auth so moving to another approach where the info is fetched regularly by a cron job that has service account credentials for `cloud.egi.eu` VO
---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
