### PR TITLE
Use site_name instead of site_id for queries

### DIFF
--- a/app/glue.py
+++ b/app/glue.py
@@ -298,7 +298,7 @@ class FileSiteStore(SiteStore):
 
     def _load_sites(self):
         sites = []
-        for file in glob.iglob(os.path.join(self.cloud_info_dir, "**"), recursive=True):
+        for file in glob.iglob(os.path.join(self.cloud_info_dir, "**/*.json"), recursive=True):
             if os.path.isfile(file):
                 sites.append(self._load_site_file(file))
                 logging.debug(f"Loaded {file}")

--- a/app/glue.py
+++ b/app/glue.py
@@ -298,7 +298,9 @@ class FileSiteStore(SiteStore):
 
     def _load_sites(self):
         sites = []
-        for file in glob.iglob(os.path.join(self.cloud_info_dir, "**/*.json"), recursive=True):
+        for file in glob.iglob(
+            os.path.join(self.cloud_info_dir, "**/*.json"), recursive=True
+        ):
             if os.path.isfile(file):
                 sites.append(self._load_site_file(file))
                 logging.debug(f"Loaded {file}")

--- a/app/main.py
+++ b/app/main.py
@@ -113,49 +113,49 @@ def get_sites(vo_name: str = "", site_name: str = "") -> list[Site]:
     return [Site(**s.summary()) for s in site_store.get_sites(vo_name)]
 
 
-def _get_site(site_id: str, vo_name: str = ""):
-    site = site_store.get_site_by_goc_id(site_id)
+def _get_site(site_name: str, vo_name: str = ""):
+    site = site_store.get_site_by_name(site_name)
     if not site:
-        raise HTTPException(status_code=404, detail=f"Site {site_id} not found")
+        raise HTTPException(status_code=404, detail=f"Site {site_name} not found")
     if vo_name and not site.supports_vo(vo_name):
         raise HTTPException(
-            status_code=404, detail=f"VO {vo_name} not supported by Site {site_id}"
+            status_code=404, detail=f"VO {vo_name} not supported by Site {site_name}"
         )
     return site
 
 
-@app.get("/site/{site_id}/", tags=["sites"])
-def get_site(site_id: str) -> Site:
+@app.get("/site/{site_name}/", tags=["sites"])
+def get_site(site_name: str) -> Site:
     """Get site information
 
-    Id matches the GOCDB id of the service
+    Name of the site in the GOCDB
     """
-    return Site(**_get_site(site_id).summary())
+    return Site(**_get_site(site_name).summary())
 
 
-@app.get("/site/{site_id}/images", tags=["sites"])
-def get_site_images(site_id: str) -> list[Image]:
+@app.get("/site/{site_name}/images", tags=["sites"])
+def get_site_images(site_name: str) -> list[Image]:
     """Get all images from a site"""
-    site = _get_site(site_id)
+    site = _get_site(site_name)
     return [Image(**img) for img in site.image_list()]
 
 
-@app.get("/site/{site_id}/{vo_name}/images", tags=["sites"])
-def get_images(site_id: str, vo_name: str) -> list[Image]:
+@app.get("/site/{site_name}/{vo_name}/images", tags=["sites"])
+def get_images(site_name: str, vo_name: str) -> list[Image]:
     """Get information about the images of a VO"""
-    site = _get_site(site_id, vo_name)
+    site = _get_site(site_name, vo_name)
     return [Image(**img) for img in site.vo_share(vo_name).image_list()]
 
 
-@app.get("/site/{site_id}/projects", tags=["sites"])
-def get_site_project_ids(site_id: str) -> list[Project]:
+@app.get("/site/{site_name}/projects", tags=["sites"])
+def get_site_project_ids(site_name: str) -> list[Project]:
     """Get information about the projects supported at a site"""
-    site = _get_site(site_id)
+    site = _get_site(site_name)
     return [Project(**share.get_project()) for share in site.shares]
 
 
-@app.get("/site/{site_id}/{vo_name}/project", tags=["sites"])
-def get_project_id(site_id: str, vo_name: str) -> Project:
+@app.get("/site/{site_name}/{vo_name}/project", tags=["sites"])
+def get_project_id(site_name: str, vo_name: str) -> Project:
     """Get information about the project supporting a VO at a site"""
-    site = _get_site(site_id, vo_name)
+    site = _get_site(site_name, vo_name)
     return Project(**site.vo_share(vo_name).get_project())

--- a/app/test_main.py
+++ b/app/test_main.py
@@ -65,7 +65,7 @@ class TestAPI(TestCase):
             m_get_site.assert_called_with("BIFI")
 
     def test__get_site(self):
-        with mock.patch.object(site_store, "get_site_by_goc_id") as m_get_site:
+        with mock.patch.object(site_store, "get_site_by_name") as m_get_site:
             m_get_site.return_value = site_fixture
             s = _get_site("foo")
             assert s == site_fixture
@@ -77,26 +77,26 @@ class TestAPI(TestCase):
                 _get_site("foo", "bar")
 
     def test__get_site_not_found(self):
-        with mock.patch.object(site_store, "get_site_by_goc_id") as m_get_site:
+        with mock.patch.object(site_store, "get_site_by_name") as m_get_site:
             m_get_site.return_value = None
             with self.assertRaises(HTTPException):
                 _get_site("foo")
 
     def test_get_site(self):
-        with mock.patch.object(site_store, "get_site_by_goc_id") as m_get_site:
+        with mock.patch.object(site_store, "get_site_by_name") as m_get_site:
             m_get_site.return_value = site_fixture
             response = self.client.get("/site/foo/")
             assert response.status_code == 200
             assert response.json() == bifi_summary
 
     def test_get_site_404(self):
-        with mock.patch.object(site_store, "get_site_by_goc_id") as m_get_site:
+        with mock.patch.object(site_store, "get_site_by_name") as m_get_site:
             m_get_site.return_value = None
             response = self.client.get("/site/foo/")
             assert response.status_code == 404
 
     def test_get_site_images(self):
-        with mock.patch.object(site_store, "get_site_by_goc_id") as m_get_site:
+        with mock.patch.object(site_store, "get_site_by_name") as m_get_site:
             m_get_site.return_value = site_fixture
             response = self.client.get("/site/foo/images/")
             assert response.status_code == 200
@@ -114,7 +114,7 @@ class TestAPI(TestCase):
             ]
 
     def test_get_site_vo_images(self):
-        with mock.patch.object(site_store, "get_site_by_goc_id") as m_get_site:
+        with mock.patch.object(site_store, "get_site_by_name") as m_get_site:
             m_get_site.return_value = site_fixture
             response = self.client.get("/site/foo/ops/images/")
             assert response.status_code == 200
@@ -132,7 +132,7 @@ class TestAPI(TestCase):
             ]
 
     def test_get_site_projects(self):
-        with mock.patch.object(site_store, "get_site_by_goc_id") as m_get_site:
+        with mock.patch.object(site_store, "get_site_by_name") as m_get_site:
             m_get_site.return_value = site_fixture
             response = self.client.get("/site/foo/projects/")
             assert response.status_code == 200
@@ -144,7 +144,7 @@ class TestAPI(TestCase):
             ]
 
     def test_get_site_vo_project(self):
-        with mock.patch.object(site_store, "get_site_by_goc_id") as m_get_site:
+        with mock.patch.object(site_store, "get_site_by_name") as m_get_site:
             m_get_site.return_value = site_fixture
             response = self.client.get("/site/foo/ops/project")
             assert response.status_code == 200


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

As discussed in https://github.com/EGI-Federation/cloud-info-api/issues/17 it is preferable to query information using `site_name` than `site_id`. This PR makes the necessary changes to implement this.

Also, a `glob` pattern is updated to only parse `json` files from `cloud-info-provider`.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :** https://github.com/EGI-Federation/cloud-info-api/issues/17
