### PR TITLE
feat: query AppDB with base mpuri for information

### DIFF
--- a/app/glue.py
+++ b/app/glue.py
@@ -8,7 +8,6 @@ import itertools
 import json
 import logging
 import os.path
-from urllib.parse import urlparse
 
 import httpx
 import xmltodict

--- a/app/test_fixtures.py
+++ b/app/test_fixtures.py
@@ -44,7 +44,7 @@ site_fixture = GlueSite(
                 GlueImage(
                     id="06c8bfac-0f93-48da-b0eb-4fbad3356f73",
                     name="EGI Small Ubuntu for Monitoring",
-                    appdb_id="egi.small.ubuntu.16.04.for.monitoring",
+                    egi_id="egi.small.ubuntu.16.04.for.monitoring",
                     mpuri="https://appdb.egi.eu/store/vo/image/63fcad1c-b737-5091-9668-1342b6d4f84c:15705/",
                     version="2024.11.18",
                     vo="ops",
@@ -69,11 +69,19 @@ another_site_fixture = GlueSite(
                 GlueImage(
                     id="06c8bfac-0f93-48da-b03b-8f8ad3356f73",
                     name="EGI Fake Image",
-                    appdb_id="egi.fake.id",
+                    egi_id="egi.fake.id",
                     mpuri="https://appdb.egi.eu/store/vo/image/0123:456/",
                     version="0.01",
                     vo="access",
-                )
+                ),
+                GlueImage(
+                    id="foobar",
+                    name="Another fake Image",
+                    egi_id="",
+                    mpuri="https://example.com/glance/vo/image/foobar",
+                    version="0.02",
+                    vo="access",
+                ),
             ],
             instancetypes=[GlueInstanceType(name="m1.small")],
         )
@@ -313,8 +321,8 @@ gocdb_fixture = """
 
 appdb_image_fixture = {
     "https://appdb.egi.eu/store/vo/image/63fcad1c-b737-5091-9668-1342b6d4f84c:15705/": {
-        "imageVAppCName": "egi.small.ubuntu.16.04.for.monitoring",
-        "imageVAppName": "EGI Small Ubuntu for Monitoring",
+        "egi_id": "egi.small.ubuntu.16.04.for.monitoring",
+        "name": "EGI Small Ubuntu for Monitoring",
         "version": "2024.11.18",
     }
 }
@@ -346,7 +354,7 @@ appdb_mpuri_fixtures = [
 
 images_fixture = [
     {
-        "appdb_id": "egi.small.ubuntu.16.04.for.monitoring",
+        "egi_id": "egi.small.ubuntu.16.04.for.monitoring",
         "endpoint": "https://colossus.cesar.unizar.es:5000/v3",
         "id": "06c8bfac-0f93-48da-b0eb-4fbad3356f73",
         "mpuri": (
@@ -358,7 +366,7 @@ images_fixture = [
         "vo": "ops",
     },
     {
-        "appdb_id": "egi.fake.id",
+        "egi_id": "egi.fake.id",
         "endpoint": "https://example.com/v3",
         "id": "06c8bfac-0f93-48da-b03b-8f8ad3356f73",
         "mpuri": "https://appdb.egi.eu/store/vo/image/0123:456/",
@@ -367,3 +375,19 @@ images_fixture = [
         "vo": "access",
     },
 ]
+
+
+appdb_file = """{
+  "data": {
+    "siteCloudComputingImages": {
+      "items": [
+        {
+          "marketPlaceURL": "foo",
+          "imageVAppCName": "egi.ubuntu.20.04",
+          "imageVAppName": "EGI Ubuntu 20.04",
+          "version": "2024.10.07"
+        }
+      ]
+    }
+  }
+}"""

--- a/app/test_fixtures.py
+++ b/app/test_fixtures.py
@@ -1,6 +1,7 @@
 """Testing our glue component"""
 
 # flake8: noqa
+import json
 
 from app.glue import GlueImage, GlueInstanceType, GlueShare, GlueSite
 
@@ -317,6 +318,31 @@ appdb_image_fixture = {
         "version": "2024.11.18",
     }
 }
+
+appdb_mpuri_fixtures = [
+    json.dumps(
+        {
+            "id": "123",
+            "title": "Small Ubuntu for monitoring",
+            "application": {
+                "cname": "egi.small.ubuntu.16.04.for.monitoring",
+                "name": "EGI Small Ubuntu for Monitoring",
+            },
+            "vappliance": {
+                "version": "2024.11.18",
+            },
+        }
+    ),
+    # to test building from
+    json.dumps(
+        {
+            "id": "123",
+            "title": "Image for Small Ubuntu for monitoring [X]",
+            "version": "2024.11.18",
+        }
+    ),
+]
+
 
 images_fixture = [
     {

--- a/app/test_glue.py
+++ b/app/test_glue.py
@@ -160,20 +160,6 @@ def test_get_site_summary():
 
 
 def test_get_appdb_no_base_mpuri():
-    with mock.patch("app.glue.SiteStore._get_mpuri_image_info") as mpuri_image_data:
-        mpuri_image_data.return_value = fixtures.appdb_image_fixture
-        site_store = app.glue.SiteStore()
-        img = site_store.get_mp_image_data(
-            {"MarketplaceURL": list(fixtures.appdb_image_fixture.keys()).pop()}
-        )
-        assert img == {
-            "imageVAppCName": "egi.small.ubuntu.16.04.for.monitoring",
-            "imageVAppName": "EGI Small Ubuntu for Monitoring",
-            "version": "2024.11.18",
-        }
-
-
-def test_get_appdb_base_mpuri_all_data():
     test_client = httpx.Client(
         transport=httpx.MockTransport(
             lambda request: httpx.Response(
@@ -184,6 +170,14 @@ def test_get_appdb_base_mpuri_all_data():
     with mock.patch("app.glue.SiteStore._get_mpuri_image_info") as mpuri_image_data:
         mpuri_image_data.return_value = fixtures.appdb_image_fixture
         site_store = app.glue.SiteStore(httpx_client=test_client)
+        img = site_store.get_mp_image_data(
+            {"MarketplaceURL": list(fixtures.appdb_image_fixture.keys()).pop()}
+        )
+        assert img == {
+            "imageVAppCName": "egi.small.ubuntu.16.04.for.monitoring",
+            "imageVAppName": "EGI Small Ubuntu for Monitoring",
+            "version": "2024.11.18",
+        }
         img = site_store.get_mp_image_data(
             {"OtherInfo": {"base_mpuri": "https://example.com"}}
         )

--- a/app/test_glue.py
+++ b/app/test_glue.py
@@ -214,9 +214,7 @@ def test_get_appdb_base_mpuri_missing_data():
 
 
 def test_read_mpuri_image_file():
-    with mock.patch(
-        "builtins.open", mock.mock_open(read_data=fixtures.appdb_file)
-    ) as mock_file:
+    with mock.patch("builtins.open", mock.mock_open(read_data=fixtures.appdb_file)):
         site_store = app.glue.SiteStore()
         assert site_store._mpuri_image_info["foo"] == {
             "egi_id": "egi.ubuntu.20.04",

--- a/app/test_glue.py
+++ b/app/test_glue.py
@@ -35,7 +35,7 @@ def test_gluesite_object():
         {
             "name": "EGI Small Ubuntu for Monitoring",
             "version": "2024.11.18",
-            "appdb_id": "egi.small.ubuntu.16.04.for.monitoring",
+            "egi_id": "egi.small.ubuntu.16.04.for.monitoring",
             "id": "06c8bfac-0f93-48da-b0eb-4fbad3356f73",
             "mpuri": (
                 "https://appdb.egi.eu/store/vo/image/"
@@ -91,7 +91,7 @@ def test_gocdb_info():
 
 def test_create_site():
     with (
-        mock.patch("app.glue.SiteStore._get_mpuri_image_info"),
+        mock.patch("app.glue.SiteStore._read_mpuri_image_file"),
         mock.patch("app.glue.SiteStore.get_mp_image_data") as image_data,
         mock.patch("app.glue.SiteStore._get_gocdb_hostname") as goc_hostname,
     ):
@@ -168,23 +168,23 @@ def test_get_appdb_no_base_mpuri():
             )
         )
     )
-    with mock.patch("app.glue.SiteStore._get_mpuri_image_info") as mpuri_image_data:
+    with mock.patch("app.glue.SiteStore._read_mpuri_image_file") as mpuri_image_data:
         mpuri_image_data.return_value = fixtures.appdb_image_fixture
         site_store = app.glue.SiteStore(httpx_client=test_client)
         img = site_store.get_mp_image_data(
             {"MarketplaceURL": list(fixtures.appdb_image_fixture.keys()).pop()}
         )
         assert img == {
-            "imageVAppCName": "egi.small.ubuntu.16.04.for.monitoring",
-            "imageVAppName": "EGI Small Ubuntu for Monitoring",
+            "egi_id": "egi.small.ubuntu.16.04.for.monitoring",
+            "name": "EGI Small Ubuntu for Monitoring",
             "version": "2024.11.18",
         }
         img = site_store.get_mp_image_data(
             {"OtherInfo": {"base_mpuri": "https://example.com"}}
         )
         assert img == {
-            "imageVAppCName": "egi.small.ubuntu.16.04.for.monitoring",
-            "imageVAppName": "EGI Small Ubuntu for Monitoring",
+            "egi_id": "egi.small.ubuntu.16.04.for.monitoring",
+            "name": "EGI Small Ubuntu for Monitoring",
             "version": "2024.11.18",
         }
 
@@ -197,17 +197,29 @@ def test_get_appdb_base_mpuri_missing_data():
             )
         )
     )
-    with mock.patch("app.glue.SiteStore._get_mpuri_image_info") as mpuri_image_data:
+    with mock.patch("app.glue.SiteStore._read_mpuri_image_file") as mpuri_image_data:
         mpuri_image_data.return_value = fixtures.appdb_image_fixture
         site_store = app.glue.SiteStore(httpx_client=test_client)
         img = site_store.get_mp_image_data(
             {"OtherInfo": {"base_mpuri": "https://example.com"}}
         )
         assert img == {
-            "imageVAppCName": "small.ubuntu.for.monitoring",
-            "imageVAppName": "Small Ubuntu for monitoring",
+            "egi_id": "small.ubuntu.for.monitoring",
+            "name": "Small Ubuntu for monitoring",
             "version": "2024.11.18",
         }
 
 
 # jscpd:ignore-end
+
+
+def test_read_mpuri_image_file():
+    with mock.patch(
+        "builtins.open", mock.mock_open(read_data=fixtures.appdb_file)
+    ) as mock_file:
+        site_store = app.glue.SiteStore()
+        assert site_store._mpuri_image_info["foo"] == {
+            "egi_id": "egi.ubuntu.20.04",
+            "name": "EGI Ubuntu 20.04",
+            "version": "2024.10.07",
+        }

--- a/app/test_glue.py
+++ b/app/test_glue.py
@@ -159,6 +159,7 @@ def test_get_site_summary():
         assert list(site_store.get_site_summary("ops")) == [site_summary]
 
 
+# jscpd:ignore-start
 def test_get_appdb_no_base_mpuri():
     test_client = httpx.Client(
         transport=httpx.MockTransport(
@@ -207,3 +208,6 @@ def test_get_appdb_base_mpuri_missing_data():
             "imageVAppName": "Small Ubuntu for monitoring",
             "version": "2024.11.18",
         }
+
+
+# jscpd:ignore-end

--- a/app/test_main.py
+++ b/app/test_main.py
@@ -144,3 +144,22 @@ class TestAPI(TestCase):
             response = self.client.get("/images", params={"vo_name": "ops"})
             assert response.status_code == 200
             assert response.json() == [images_fixture[0]]
+
+    def test_get_images_non_egi(self):
+        with mock.patch.object(site_store, "get_sites") as m_get_sites:
+            m_get_sites.return_value = [site_fixture, another_site_fixture]
+            response = self.client.get("/images", params={"only_egi_images": False})
+            assert response.status_code == 200
+            images = images_fixture.copy()
+            images.append(
+                {
+                    "egi_id": "",
+                    "endpoint": "https://example.com/v3",
+                    "id": "foobar",
+                    "mpuri": "https://example.com/glance/vo/image/foobar",
+                    "name": "Another fake Image",
+                    "version": "0.02",
+                    "vo": "access",
+                }
+            )
+            assert response.json() == images


### PR DESCRIPTION
<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary
As AppDB updates the images and its is is not functional, the image information needs to be retrieved in an alternative way. Using the `base_mpuri` seems to provide the needed information, although we miss the version

<!-- Describe in plain English what this PR does -->

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
