### PR TITLE
Allow for proxied setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ HEALTHCHECK CMD uv tool run --from httpie http localhost
 
 # Run the application.
 ENTRYPOINT ["tini", "--"]
-CMD ["/app/.venv/bin/fastapi", "run", "app/main.py", "--port", "80", "--host", "0.0.0.0"]
+CMD ["/app/.venv/bin/fastapi", "run", "app/main.py", "--port", "80", "--host", "0.0.0.0", "--forwarded-allow-ips=*"]


### PR DESCRIPTION

<!--
A good PR should describe what benefit this brings to the repository.
Ideally, there is an existing issue which the PR address.

Please check the Contributing guide CONTRIBUTING.md for style requirements and
advice.
-->

# Summary

<!-- Describe in plain English what this PR does -->
Our fastapi app is behind traefik and as such should trust the forwarded headers from that proxy. 
Adding the --forwarded-allow-ips=* option as described in https://fastapi.tiangolo.com/advanced/behind-a-proxy/

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
